### PR TITLE
fix: pub date and sync hugo versions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.105.0'
           # extended: true
 
       - name: Build

--- a/content/smb-tailscale/index.md
+++ b/content/smb-tailscale/index.md
@@ -1,6 +1,6 @@
 ---
 author: "Dan Salmon"
-date: "2024-03-15T00:00:00Z"
+date: "2024-11-11T00:00:00Z"
 description: "SMB speeds can be severely impacted when multiple interfaces can reach a network."
 draft: false
 tags: ["windows", "tailscale"]


### PR DESCRIPTION
Maybe look at making a `.hugo-version` file or something that both the Dockerfile and workflow file can read from.